### PR TITLE
Added attempt error logging to PPA repository

### DIFF
--- a/setup-llvmpipe-lavapipe/action.yml
+++ b/setup-llvmpipe-lavapipe/action.yml
@@ -7,8 +7,14 @@ runs:
       shell: bash
       run: |
         sudo apt-get update -y -qq
+        sudo apt-get install -y software-properties-common apt-transport-https ca-certificates
         for i in {1..5}; do
-          sudo add-apt-repository ppa:kisak/kisak-mesa -y && break || sleep 5;
+          sudo add-apt-repository ppa:kisak/kisak-mesa -y && break || {
+            echo "Attempt $i to add the PPA repository failed, retrying in 5 seconds..."
+            sleep 5
+          }
         done
         sudo apt-get update
         sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        # Verify installation
+        vulkaninfo --summary || echo "Vulkan installation verification failed"


### PR DESCRIPTION
I modified the error logging of adding the PPA repository so developers can know which attempt(s) failed. I also included some missing dependencies and an ending statement to verify the vulkan installation.

Related Issue: [#2812](https://github.com/tracel-ai/burn/issues/2812) from the main Burn repo.