### PR TITLE
Add input to copy files for docs before publish

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ""
+      extra-docs:
+        required: false
+        type: string
+        default: ""   # space-separated list of files to copy
     secrets:
       CRATES_IO_API_TOKEN:
         required: true
@@ -33,6 +37,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ${{ inputs.apt-packages }}
+
+      - name: copy extra docs
+        if: ${{ inputs.extra-docs != '' }}
+        run: |
+          for file in ${{ inputs.extra-docs }}; do
+            cp "$file" "crates/${{ inputs.crate }}/"
+          done
 
       - name: publish to crates.io
         run: cargo xtask publish ${{ inputs.crate }}

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
         default: ""
-      extra-docs:
+      copy-doc-assets:
         required: false
         type: string
         default: ""   # space-separated list of files to copy
@@ -39,9 +39,9 @@ jobs:
           sudo apt-get install -y ${{ inputs.apt-packages }}
 
       - name: copy extra docs
-        if: ${{ inputs.extra-docs != '' }}
+        if: ${{ inputs.copy-doc-assets != '' }}
         run: |
-          for file in ${{ inputs.extra-docs }}; do
+          for file in ${{ inputs.copy-doc-assets }}; do
             cp "$file" "crates/${{ inputs.crate }}/"
           done
 

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ inputs.apt-packages }}
 
-      - name: copy extra docs
+      - name: copy doc assets
         if: ${{ inputs.copy-doc-assets != '' }}
         run: |
           for file in ${{ inputs.copy-doc-assets }}; do


### PR DESCRIPTION
We now have LaTeX equations in the docs for some burn crates. Renders nicely on docs.rs (when the header is linked correctly).

For the build to work the katex-header.html needs to be in the crates directory, docs.rs build does not have access to the workspace.

Instead of keeping a copy for each crate in the repo, allow copying the files via:

```diff
publish-burn-nn:
  uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v4
  with:
    crate: burn-nn
+   copy-doc-assets: "docs/katex-header.html"
  secrets:
    CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
```

The doc assets will be copied from the workspace to the crate during the workflow.