### PR TITLE
Ignore doc assets untracked changes for cargo publish

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -47,6 +47,9 @@ jobs:
         run: |
           for file in ${{ inputs.copy-doc-assets }}; do
             cp "$file" "crates/${{ inputs.crate }}/"
+            # Add to git per-checkout exclude
+            # This is a cargo publish fix instead of using --allow-dirty for the whole crate
+            echo "crates/${{ inputs.crate }}/$(basename "$file")" >> .git/info/exclude
           done
 
       - name: publish to crates.io


### PR DESCRIPTION
Fixes this job failure:
https://github.com/tracel-ai/burn/actions/runs/18880541342/job/53882178585

```
Publishing crate 'burn-tensor'...
  Local version: 0.19.0
  Found remote version: 0.18.0
  Command line: cargo publish -p burn-tensor --dry-run
      Updating crates.io index
  error: 1 files in the working directory contain changes that were not yet committed into git:
  
  crates/burn-tensor/katex-header.html
  
  to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
  Error: Publish dry run failed for crate 'burn-tensor'. (exit status: 101)
  ```